### PR TITLE
Break when reaching body or document

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,8 @@ function getVisibleRectForElement(element) {
       visibleRect.bottom = Math.min(visibleRect.bottom,
         pos.top + el.clientHeight);
       visibleRect.left = Math.max(visibleRect.left, pos.left);
+    } else {
+      break;
     }
   }
 


### PR DESCRIPTION
Not having this break caused an error with the ownerDocument being null and d.defaultView throwing an error.