### PR TITLE
 Do not flip If target region has smaller size than origin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ notifications:
   - yiminghe@gmail.com
 
 node_js:
-- 4.0.0
-
+  - "6"
+  
 before_install:
 - |
     if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.md$)|(^(docs|examples))/'

--- a/src/adjustForViewport.js
+++ b/src/adjustForViewport.js
@@ -1,45 +1,45 @@
 import utils from './utils';
 
-function adjustForViewport(elFuturePos, elRegion, visibleRect, overflow) {
+function adjustForViewport(elFuturePos, elRegion, xRect, yRect, overflow) {
   const pos = utils.clone(elFuturePos);
   const size = {
     width: elRegion.width,
     height: elRegion.height,
   };
 
-  if (overflow.adjustX && pos.left < visibleRect.left) {
-    pos.left = visibleRect.left;
+  if (overflow.adjustX && pos.left < xRect.left) {
+    pos.left = xRect.left;
   }
 
   // Left edge inside and right edge outside viewport, try to resize it.
   if (overflow.resizeWidth &&
-    pos.left >= visibleRect.left &&
-    pos.left + size.width > visibleRect.right) {
-    size.width -= (pos.left + size.width) - visibleRect.right;
+    pos.left >= xRect.left &&
+    pos.left + size.width > xRect.right) {
+    size.width -= (pos.left + size.width) - xRect.right;
   }
 
   // Right edge outside viewport, try to move it.
-  if (overflow.adjustX && pos.left + size.width > visibleRect.right) {
+  if (overflow.adjustX && pos.left + size.width > xRect.right) {
     // 保证左边界和可视区域左边界对齐
-    pos.left = Math.max(visibleRect.right - size.width, visibleRect.left);
+    pos.left = Math.max(xRect.right - size.width, xRect.left);
   }
 
   // Top edge outside viewport, try to move it.
-  if (overflow.adjustY && pos.top < visibleRect.top) {
-    pos.top = visibleRect.top;
+  if (overflow.adjustY && pos.top < yRect.top) {
+    pos.top = yRect.top;
   }
 
   // Top edge inside and bottom edge outside viewport, try to resize it.
   if (overflow.resizeHeight &&
-    pos.top >= visibleRect.top &&
-    pos.top + size.height > visibleRect.bottom) {
-    size.height -= (pos.top + size.height) - visibleRect.bottom;
+    pos.top >= yRect.top &&
+    pos.top + size.height > yRect.bottom) {
+    size.height -= (pos.top + size.height) - yRect.bottom;
   }
 
   // Bottom edge outside viewport, try to move it.
-  if (overflow.adjustY && pos.top + size.height > visibleRect.bottom) {
+  if (overflow.adjustY && pos.top + size.height > yRect.bottom) {
     // 保证上边界和可视区域上边界对齐
-    pos.top = Math.max(visibleRect.bottom - size.height, visibleRect.top);
+    pos.top = Math.max(yRect.bottom - size.height, yRect.top);
   }
 
   return utils.mix(pos, size);

--- a/tests/index.js
+++ b/tests/index.js
@@ -291,6 +291,7 @@ describe('dom-align', () => {
           expect(target.offset().top - containerOffset.top).to.be(55);
         });
 
+
         it('should not auto adjust if target is out of visible rect', () => {
           if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
             return;
@@ -326,6 +327,44 @@ describe('dom-align', () => {
 
           expect(source.offset().top - target.offset().top).to.be(0);
           expect(source.offset().left - target.offset().left).to.be(0);
+        });
+
+        it('should not flip if target area is smaller than origin', () => {
+          if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
+            return;
+          }
+          const node = $(`<div style='position: absolute;left:100px;top:100px;
+          width: 100px;height: 100px;
+          overflow: hidden'>
+          <div style='position: absolute;
+          width: 50px;
+          height: 100px;'>
+          </div>
+          <div style='position: absolute;left:0;top:20px;'></div>
+          <div style='position: absolute;left:0;top:30px;'></div>
+          </div>`).appendTo('body');
+
+          const target = node.children().eq(0);
+          // upper = node.children().eq(1),
+          const lower = node.children().eq(2);
+
+          const containerOffset = node.offset();
+          domAlign(target[0], lower[0], {
+            points: ['tl', 'bl'],
+            overflow: {
+              adjustY: 1,
+              resizeHeight: 1,
+            },
+          });
+          //   | ___________ |
+          //   |      |      |
+          //   | ____ | ____ |
+          //   |      |      |
+          //   |      |      |
+          //   |------|______|
+
+          expect(target.offset().left - containerOffset.left).within(-5, 5);
+          expect(target.offset().top - containerOffset.top - 30).within(-5, 5);
         });
 
         it('should auto adjust if current position is not right', () => {


### PR DESCRIPTION
 + close https://github.com/ant-design/ant-design/issues/5034


当 y 方向放不下时，先判断 y 的翻转区域是否比当前区域面积大，如果翻转区域的可用高度比当前区域小，则不做翻转。x 轴同理。

如图： 原先的处理，target 距顶端1格，距底端 2 格, 要 align 一个 3格的 DOM，会向上部弹出。

```
|------|
|      |
| _____|_____ |
|      |      |
| ____ | ____ |
|      |      |
|      |      |
|______|______|

```

更改之后，会向下弹出，因为下部的可用空间高度比上部高。
```
| ___________ |
|      |      |
| ____ | ____ |
|      |      |
|      |      |
|______|______|
|------|
```