### PR TITLE
Fix auto adjust

### DIFF
--- a/examples/fail.js
+++ b/examples/fail.js
@@ -10,7 +10,7 @@ const Test = React.createClass({
         adjustY: 1,
       },
     });
-    console.log(ret);
+    console.log(ret); // eslint-disable-line
   },
   render() {
     window.align = this.align;

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,37 @@ function normalizeOffset(offset, el) {
   offset[1] = convertOffset(offset[1], el.height);
 }
 
+// If page is not scrollable, then use VisibleRect of browser edge
+function fixVisibleRect(region, visibleRect) {
+  if (typeof document === 'undefined') {
+    return region;
+  }
+  const scrollTop = document.documentElement.scrollTop;
+  const scrollLeft = document.documentElement.scrollLeft;
+  const scrollWidth = document.documentElement.scrollWidth;
+  const scrollHeight = document.documentElement.scrollHeight;
+  const windowWidth = window.innerWidth;
+  const windowHeight = window.innerHeight;
+  const newRegion = { ...region };
+  // 不可向上滚动
+  if (scrollTop === 0) {
+    newRegion.top = visibleRect.top;
+  }
+  // 不可向下滚动
+  if (scrollTop + windowHeight === scrollHeight) {
+    newRegion.bottom = visibleRect.bottom;
+  }
+  // 不可向左滚动
+  if (scrollLeft === 0) {
+    newRegion.left = visibleRect.left;
+  }
+  // 不可向右滚动
+  if (scrollLeft + windowWidth === scrollWidth) {
+    newRegion.right = visibleRect.right;
+  }
+  return newRegion;
+}
+
 function domAlign(el, refNode, align) {
   let points = align.points;
   let offset = align.offset || [0, 0];
@@ -214,6 +245,10 @@ function domAlign(el, refNode, align) {
         }
       }
     }
+
+    // 根据是否能滚动修正可视区域
+    realXRegion = fixVisibleRect(realXRegion, visibleRect);
+    realYRegion = fixVisibleRect(realYRegion, visibleRect);
 
     // 如果失败，重新计算当前节点将要被放置的位置
     if (fail) {

--- a/src/index.js
+++ b/src/index.js
@@ -154,10 +154,18 @@ function domAlign(el, refNode, align) {
         const newElFuturePos = getElFuturePos(elRegion, refNodeRegion,
           newPoints, newOffset, newTargetOffset);
 
-        const XregionReversal = utils.merge(visibleRect, {
-          [newPoints[0].charAt(1) === 'l' ?
-            'left' : 'right']: getAlignOffset(refNodeRegion, newPoints[1]).left,
-        });
+        let XregionReversal;
+        if (newPoints[0].charAt(1) === 'c') {
+          XregionReversal = utils.merge(visibleRect, {
+            left: refNodeOffset.left - elRegion.width / 2,
+          });
+        } else {
+          XregionReversal = utils.merge(visibleRect, {
+            [newPoints[0].charAt(1) === 'l' ?
+              'left' : 'right']: getAlignOffset(refNodeRegion, newPoints[1]).left,
+          });
+        }
+
         const canXFlip = xSize(XregionReversal) > xSize(Xregion);
         if (canXFlip && !isCompleteFailX(newElFuturePos, elRegion, visibleRect)) {
           fail = 1;
@@ -183,10 +191,18 @@ function domAlign(el, refNode, align) {
         const newElFuturePos = getElFuturePos(elRegion, refNodeRegion,
           newPoints, newOffset, newTargetOffset);
 
-        const YRegionReversal = utils.merge(visibleRect, {
-          [newPoints[0].charAt(0) === 't' ?
-            'top' : 'bottom']: getAlignOffset(refNodeRegion, newPoints[1]).top,
-        });
+        let YRegionReversal;
+        if (newPoints[0].charAt(0) === 'c') {
+          YRegionReversal = utils.merge(visibleRect, {
+            top: refNodeOffset.top - elRegion.height / 2,
+          });
+        } else {
+          YRegionReversal = utils.merge(visibleRect, {
+            [newPoints[0].charAt(0) === 't' ?
+              'top' : 'bottom']: getAlignOffset(refNodeRegion, newPoints[1]).top,
+          });
+        }
+
         const canYFlip = ySize(YRegionReversal) > ySize(YRegion);
 
         if (canYFlip && !isCompleteFailY(newElFuturePos, elRegion, visibleRect)) {

--- a/src/index.js
+++ b/src/index.js
@@ -83,17 +83,22 @@ function normalizeOffset(offset, el) {
 }
 
 // If page is not scrollable, then use VisibleRect of browser edge
-function fixVisibleRect(region, visibleRect) {
+function fixVisibleRect(region, visibleRect, sourceNode) {
   if (typeof document === 'undefined') {
     return region;
   }
-  const scrollTop = document.documentElement.scrollTop;
-  const scrollLeft = document.documentElement.scrollLeft;
-  const scrollWidth = document.documentElement.scrollWidth;
-  const scrollHeight = document.documentElement.scrollHeight;
-  const windowWidth = window.innerWidth;
-  const windowHeight = window.innerHeight;
+  let offsetParent = getOffsetParent(sourceNode);
+  if (offsetParent === document.body) {
+    offsetParent = document.documentElement;
+  }
+  const scrollTop = offsetParent.scrollTop;
+  const scrollLeft = offsetParent.scrollLeft;
+  const scrollWidth = offsetParent.scrollWidth;
+  const scrollHeight = offsetParent.scrollHeight;
+  const windowWidth = offsetParent.clientWidth;
+  const windowHeight = offsetParent.clientHeight;
   const newRegion = { ...region };
+
   // 不可向上滚动
   if (scrollTop === 0) {
     newRegion.top = visibleRect.top;
@@ -247,8 +252,8 @@ function domAlign(el, refNode, align) {
     }
 
     // 根据是否能滚动修正可视区域
-    realXRegion = fixVisibleRect(realXRegion, visibleRect);
-    realYRegion = fixVisibleRect(realYRegion, visibleRect);
+    realXRegion = fixVisibleRect(realXRegion, visibleRect, source);
+    realYRegion = fixVisibleRect(realYRegion, visibleRect, source);
 
     // 如果失败，重新计算当前节点将要被放置的位置
     if (fail) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -394,6 +394,43 @@ describe('dom-align', () => {
           expect(source.offset().left - target.offset().left).to.be(0);
         });
 
+        it('auto adjust should depends on whether offset parent is scrollable', () => {
+          if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
+            return;
+          }
+          const node = $(`
+           <div style='position:absolute;left:0;top:0;width:100px;height:100px;overflow:scroll;'>
+             <div style='position:absolute;width:50px;height:50px;'></div>
+             <div style='position:absolute;top:-10px;left:-10px;width:50px;height:50px;'></div>
+             <div style='width:1000px;height:1000px;'>1111</div>
+           </div>
+          `).appendTo('body');
+
+          const source = node.children().eq(0);
+          const target = node.children().eq(1);
+          domAlign(source[0], target[0], {
+            points: ['tl', 'tl'],
+            overflow: {
+              adjustX: 1,
+              adjustY: 1,
+            },
+          });
+          expect(source.offset().top).to.be(0);
+          expect(source.offset().left).to.be(0);
+
+          node[0].scrollTop = 20;
+          node[0].scrollLeft = 20;
+          domAlign(source[0], target[0], {
+            points: ['tl', 'tl'],
+            overflow: {
+              adjustX: 1,
+              adjustY: 1,
+            },
+          });
+          expect(source.offset().top - target.offset().top).to.be(0);
+          expect(source.offset().left - target.offset().left).to.be(0);
+        });
+
         it('should not flip if target area is smaller than origin', () => {
           if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
             return;


### PR DESCRIPTION
<img width="475" alt="image" src="https://user-images.githubusercontent.com/507615/27440400-34fbe9a8-579d-11e7-8bcb-eaa056c6a323.png">

修复 https://github.com/yiminghe/dom-align/commit/aaac734c280ea70c1f2c9e086a9ce3bdee3169f3 改动导致的，元素在不可滚动的边缘外时，不会调整位置的问题。

<img width="904" alt="2017-06-22 22 44 19" src="https://user-images.githubusercontent.com/507615/27440338-fc02e264-579c-11e7-9c01-ae4352f1b765.png">

方法是检查边缘是否可滚动，如果可滚动，依然保持 https://github.com/yiminghe/dom-align/commit/aaac734c280ea70c1f2c9e086a9ce3bdee3169f3 乃至 https://github.com/ant-design/ant-design/issues/5034 的修正逻辑。如果不可滚动，需要强制定位到浏览器可视区域内。

---

另外还修复了，在右方和下方自动调整位置的偏差。

<img width="905" alt="2017-06-22 22 44 25" src="https://user-images.githubusercontent.com/507615/27440379-23e23096-579d-11e7-9544-07618a1cc5a5.png">
