### PR TITLE
fix: behavior of dom-align

### DIFF
--- a/src/adjustForViewport.js
+++ b/src/adjustForViewport.js
@@ -1,45 +1,45 @@
 import utils from './utils';
 
-function adjustForViewport(elFuturePos, elRegion, xRect, yRect, overflow) {
+function adjustForViewport(elFuturePos, elRegion, visibleRect, overflow) {
   const pos = utils.clone(elFuturePos);
   const size = {
     width: elRegion.width,
     height: elRegion.height,
   };
 
-  if (overflow.adjustX && pos.left < xRect.left) {
-    pos.left = xRect.left;
+  if (overflow.adjustX && pos.left < visibleRect.left) {
+    pos.left = visibleRect.left;
   }
 
   // Left edge inside and right edge outside viewport, try to resize it.
   if (overflow.resizeWidth &&
-    pos.left >= xRect.left &&
-    pos.left + size.width > xRect.right) {
-    size.width -= (pos.left + size.width) - xRect.right;
+    pos.left >= visibleRect.left &&
+    pos.left + size.width > visibleRect.right) {
+    size.width -= (pos.left + size.width) - visibleRect.right;
   }
 
   // Right edge outside viewport, try to move it.
-  if (overflow.adjustX && pos.left + size.width > xRect.right) {
+  if (overflow.adjustX && pos.left + size.width > visibleRect.right) {
     // 保证左边界和可视区域左边界对齐
-    pos.left = Math.max(xRect.right - size.width, xRect.left);
+    pos.left = Math.max(visibleRect.right - size.width, visibleRect.left);
   }
 
   // Top edge outside viewport, try to move it.
-  if (overflow.adjustY && pos.top < yRect.top) {
-    pos.top = yRect.top;
+  if (overflow.adjustY && pos.top < visibleRect.top) {
+    pos.top = visibleRect.top;
   }
 
   // Top edge inside and bottom edge outside viewport, try to resize it.
   if (overflow.resizeHeight &&
-    pos.top >= yRect.top &&
-    pos.top + size.height > yRect.bottom) {
-    size.height -= (pos.top + size.height) - yRect.bottom;
+    pos.top >= visibleRect.top &&
+    pos.top + size.height > visibleRect.bottom) {
+    size.height -= (pos.top + size.height) - visibleRect.bottom;
   }
 
   // Bottom edge outside viewport, try to move it.
-  if (overflow.adjustY && pos.top + size.height > yRect.bottom) {
+  if (overflow.adjustY && pos.top + size.height > visibleRect.bottom) {
     // 保证上边界和可视区域上边界对齐
-    pos.top = Math.max(yRect.bottom - size.height, yRect.top);
+    pos.top = Math.max(visibleRect.bottom - size.height, visibleRect.top);
   }
 
   return utils.mix(pos, size);

--- a/src/getVisibleRectForElement.js
+++ b/src/getVisibleRectForElement.js
@@ -12,9 +12,6 @@ function getVisibleRectForElement(element) {
     bottom: Infinity,
   };
   let el = getOffsetParent(element);
-  let scrollX;
-  let scrollY;
-  let winSize;
   const doc = utils.getDocument(element);
   const win = doc.defaultView || doc.parentWindow;
   const body = doc.body;
@@ -50,21 +47,23 @@ function getVisibleRectForElement(element) {
     el = getOffsetParent(el);
   }
 
-  // Clip by window's viewport.
-  scrollX = utils.getWindowScrollLeft(win);
-  scrollY = utils.getWindowScrollTop(win);
-  visibleRect.left = Math.max(visibleRect.left, scrollX);
-  visibleRect.top = Math.max(visibleRect.top, scrollY);
-  winSize = {
-    width: utils.viewportWidth(win),
-    height: utils.viewportHeight(win),
-  };
-  visibleRect.right = Math.min(visibleRect.right, scrollX + winSize.width);
-  visibleRect.bottom = Math.min(visibleRect.bottom, scrollY + winSize.height);
-  return visibleRect.top >= 0 && visibleRect.left >= 0 &&
-  visibleRect.bottom > visibleRect.top &&
-  visibleRect.right > visibleRect.left ?
-    visibleRect : null;
+  // Clip by document's size.
+  const scrollX = utils.getWindowScrollLeft(win);
+  const viewportWidth = utils.viewportWidth(win);
+  const maxVisibleWidth = Math.max(documentElement.scrollWidth, scrollX + viewportWidth);
+  visibleRect.right = Math.min(visibleRect.right, maxVisibleWidth);
+
+  const scrollY = utils.getWindowScrollTop(win);
+  const viewportHeight = utils.viewportHeight(win);
+  const maxVisibleHeight = Math.max(documentElement.scrollHeight, scrollY + viewportHeight);
+  visibleRect.bottom = Math.min(visibleRect.bottom, maxVisibleHeight);
+
+  return (
+    visibleRect.top >= 0 &&
+      visibleRect.left >= 0 &&
+      visibleRect.bottom > visibleRect.top &&
+      visibleRect.right > visibleRect.left
+  ) ? visibleRect : null;
 }
 
 export default getVisibleRectForElement;

--- a/tests/index.js
+++ b/tests/index.js
@@ -394,44 +394,6 @@ describe('dom-align', () => {
           expect(source.offset().left - target.offset().left).to.be(0);
         });
 
-        it('should not flip if target area is smaller than origin', () => {
-          if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
-            return;
-          }
-          const node = $(`<div style='position: absolute;left:100px;top:100px;
-          width: 100px;height: 100px;
-          overflow: hidden'>
-          <div style='position: absolute;
-          width: 50px;
-          height: 100px;'>
-          </div>
-          <div style='position: absolute;left:0;top:20px;'></div>
-          <div style='position: absolute;left:0;top:30px;'></div>
-          </div>`).appendTo('body');
-
-          const target = node.children().eq(0);
-          // upper = node.children().eq(1),
-          const lower = node.children().eq(2);
-
-          const containerOffset = node.offset();
-          domAlign(target[0], lower[0], {
-            points: ['tl', 'bl'],
-            overflow: {
-              adjustY: 1,
-              resizeHeight: 1,
-            },
-          });
-          //   | ___________ |
-          //   |      |      |
-          //   | ____ | ____ |
-          //   |      |      |
-          //   |      |      |
-          //   |------|______|
-
-          expect(target.offset().left - containerOffset.left).within(-5, 5);
-          expect(target.offset().top - containerOffset.top - 30).within(-5, 5);
-        });
-
         it('should auto adjust if current position is not right', () => {
           if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
             return;

--- a/tests/index.js
+++ b/tests/index.js
@@ -89,27 +89,26 @@ describe('dom-align', () => {
           // 1
           window.scrollTo(10, 10);
 
-          const right = 10 + $(window).width();
-          const bottom = 10 + $(window).height();
+          const documentWidth = document.documentElement.scrollWidth;
+          const documentHeight = document.documentElement.scrollHeight;
 
           let rect = getVisibleRectForElement(dom[0].firstChild);
-
-          expect(rect.left - 10).within(-10, 10);
-          expect(rect.top - 10).within(-10, 10);
-          expect(rect.right - right).within(-10, 10);
-          expect(rect.bottom - bottom).within(-10, 10);
+          expect(rect.left).to.eql(0);
+          expect(rect.top).to.eql(0);
+          expect(rect.right).to.eql(documentWidth);
+          expect(rect.bottom).to.eql(documentHeight);
 
           if (navigator.userAgent.toLowerCase().indexOf('phantomjs') !== -1) {
             return done();
           }
 
           window.scrollTo(200, 200);
-          rect = getVisibleRectForElement(dom[0].firstChild);
 
-          expect(rect.left).to.eql(200);
-          expect(rect.bottom).to.eql(200 + $(window).height());
-          expect(rect.top).to.eql(200);
-          expect(rect.right).to.eql(200 + $(window).width());
+          rect = getVisibleRectForElement(dom[0].firstChild);
+          expect(rect.left).to.eql(0);
+          expect(rect.top).to.eql(0);
+          expect(rect.right).to.eql(documentWidth);
+          expect(rect.bottom).to.eql(documentHeight);
 
           $(dom[0]).remove();
 
@@ -117,45 +116,60 @@ describe('dom-align', () => {
           window.scrollTo(10, 10);
           rect = getVisibleRectForElement(dom[1].firstChild);
           expect(toBeEqualRect(rect, {
-            left: 10,
-            top: 10,
+            left: 0,
+            top: $(dom[1]).offset().top,
             right: 100,
-            bottom: 100,
+            bottom: $(dom[1]).offset().top + 100,
           })).to.be.ok();
 
           window.scrollTo(200, 200);
           rect = getVisibleRectForElement(dom[1].firstChild);
-          expect(rect).to.be(null);
+          expect(toBeEqualRect(rect, {
+            left: 0,
+            top: $(dom[1]).offset().top,
+            right: 100,
+            bottom: $(dom[1]).offset().top + 100,
+          })).to.be.ok();
           $(dom[1]).remove();
 
           // 3
           window.scrollTo(10, 10);
           rect = getVisibleRectForElement(dom[2].firstChild);
           expect(toBeEqualRect(rect, {
-            left: 10,
-            top: 10,
+            left: 0,
+            top: $(dom[2]).offset().top,
             right: 100,
-            bottom: 100,
+            bottom: $(dom[2]).offset().top + 100,
           })).to.be.ok();
 
           window.scrollTo(200, 200);
           rect = getVisibleRectForElement(dom[2].firstChild);
-          expect(rect).to.be(null);
+          expect(toBeEqualRect(rect, {
+            left: 0,
+            top: $(dom[2]).offset().top,
+            right: 100,
+            bottom: $(dom[2]).offset().top + 100,
+          })).to.be.ok();
           $(dom[2]).remove();
 
           // 4
           window.scrollTo(10, 10);
           rect = getVisibleRectForElement(dom[3].firstChild);
           expect(toBeEqualRect(rect, {
-            left: 10,
-            top: 10,
+            left: 0,
+            top: $(dom[3]).offset().top,
             right: 100,
-            bottom: 100,
+            bottom: $(dom[3]).offset().top + 100,
           })).to.be.ok();
 
           window.scrollTo(200, 200);
           rect = getVisibleRectForElement(dom[3].firstChild);
-          expect(rect).to.be(null);
+          expect(toBeEqualRect(rect, {
+            left: 0,
+            top: $(dom[3]).offset().top,
+            right: 100,
+            bottom: $(dom[3]).offset().top + 100,
+          })).to.be.ok();
           $(dom[3]).remove();
           $(gap).remove();
 


### PR DESCRIPTION
Close: https://github.com/ant-design/ant-design/issues/5130

1. revert: aaac734 , 在 dom-align 这层是无法实现 flip 过后就不 flip 回来的逻辑的 cc @RaoHai 
1. 修改 visible 的定义，能通过滚到到达的区域，也理解为可见区域
