### PR TITLE
add ignoreShake to skip re-align

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -30,6 +30,8 @@ function align() {
     useCssRight: $id('useCssRight').checked,
     useCssBottom: $id('useCssBottom').checked,
     useCssTransform: $id('useCssTransform').checked,
+
+    ignoreShake: $id('ignoreShake').checked,
   });
 }
 
@@ -115,6 +117,12 @@ const div = (<div>
 
     &nbsp;
 
+    <label>ignoreShake:
+      <input type="checkbox" id="ignoreShake" />
+    </label>
+
+    &nbsp;
+
     <button id="align" onClick={align}>align</button>
     <br/>
 
@@ -142,16 +150,24 @@ const div = (<div>
       <div
         style={{
           background: 'red',
-          width: 50,
-          height: 50,
+          width: 80,
+          height: 80,
           left: 0,
           top: 0,
           position: 'absolute',
           transition: 'all 0.5s',
+          overflowY: 'auto',
         }}
         id="source"
       >
         source node
+
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
+        <br />
       </div>
     </div>
   </div>

--- a/src/align/align.js
+++ b/src/align/align.js
@@ -190,6 +190,7 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
     useCssRight: align.useCssRight,
     useCssBottom: align.useCssBottom,
     useCssTransform: align.useCssTransform,
+    ignoreShake: align.ignoreShake,
   });
 
   return {

--- a/src/utils.js
+++ b/src/utils.js
@@ -298,8 +298,21 @@ function setTransform(elem, offset) {
   setTransformXY(elem, resultXY);
 }
 
-
 function setOffset(elem, offset, option) {
+  if (option.ignoreShake) {
+    const oriOffset = getOffset(elem);
+
+    const oLeft = oriOffset.left.toFixed(0);
+    const oTop = oriOffset.top.toFixed(0);
+    const tLeft = offset.left.toFixed(0);
+    const tTop = offset.top.toFixed(0);
+
+    if (oLeft === tLeft && oTop === tTop) {
+      return;
+    }
+  }
+
+
   if (option.useCssRight || option.useCssBottom) {
     setLeftTop(elem, offset, option);
   } else if (option.useCssTransform && getTransformName() in document.body.style) {


### PR DESCRIPTION
IE 下 align 会导致滚动条重置。添加 `ignoreShake` 属性，当位置接近时不做 re-align。

重现步骤：
1. 在 IE 9 ~ 11 下打开 simple example
2. 去掉 ‘useCssTransform’ 
3. 滚动 source node
4. 点击 align 按钮

滚动条重置