### PR TITLE
adjust value when overflow: hidden

### DIFF
--- a/examples/body-overflow.js
+++ b/examples/body-overflow.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import domAlign from 'dom-align';
+import ReactDOM from 'react-dom';
+
+const Test = React.createClass({
+  align() {
+    const ret = domAlign(this.refs.source, this.refs.target, {
+      points: ['tl', 'bl'],
+      overflow: {
+        adjustY: 1,
+        adjustX: 1,
+      },
+    });
+    console.log(ret);
+
+    setTimeout(() => {
+      document.body.style.overflow = 'hidden';
+    }, 1000);
+  },
+  render() {
+    window.align = this.align;
+    return (<div style={{ height: 1000 }}>
+      <button ref="target" style={{ position: 'absolute', right: 0, top: 300 }}>target</button>
+
+      <div style={{ height: 100 }}/>
+
+      <button onClick={this.align}>align</button>
+
+      <div
+        ref="source"
+        style={{ position: 'absolute', width: 100, height: 200, border: '1px solid red' }}
+      >
+        oo
+      </div>
+    </div>);
+  },
+});
+
+ReactDOM.render(<Test />, document.getElementById('__react-content'));

--- a/src/getVisibleRectForElement.js
+++ b/src/getVisibleRectForElement.js
@@ -64,8 +64,18 @@ function getVisibleRectForElement(element) {
   const scrollY = utils.getWindowScrollTop(win);
   const viewportWidth = utils.viewportWidth(win);
   const viewportHeight = utils.viewportHeight(win);
-  const documentWidth = documentElement.scrollWidth;
-  const documentHeight = documentElement.scrollHeight;
+  let documentWidth = documentElement.scrollWidth;
+  let documentHeight = documentElement.scrollHeight;
+
+  // scrollXXX on html is sync with body which means overflow: hidden on body gets wrong scrollXXX.
+  // We should cut this ourself.
+  const bodyStyle = getComputedStyle(body);
+  if (bodyStyle.overflowX === 'hidden') {
+    documentWidth = win.innerWidth;
+  }
+  if (bodyStyle.overflowY === 'hidden') {
+    documentHeight = win.innerHeight;
+  }
 
   // Reset element position after calculate the visible area
   if (element.style) {


### PR DESCRIPTION
当 body style 设置为 overflow: hidden 时只切 window 的 clientXXX 作为 visibleReact。

PS：jsdom 里行为和游览器不一致，没法写测试。有点蛋疼。

ref: https://github.com/ant-design/ant-design/issues/15107