### PR TITLE
round number

### DIFF
--- a/src/getElFuturePos.js
+++ b/src/getElFuturePos.js
@@ -6,8 +6,8 @@ function getElFuturePos(elRegion, refNodeRegion, points, offset, targetOffset) {
   const diff = [p2.left - p1.left, p2.top - p1.top];
 
   return {
-    left: elRegion.left - diff[0] + offset[0] - targetOffset[0],
-    top: elRegion.top - diff[1] + offset[1] - targetOffset[1],
+    left: Math.round(elRegion.left - diff[0] + offset[0] - targetOffset[0]),
+    top: Math.round(elRegion.top - diff[1] + offset[1] - targetOffset[1]),
   };
 }
 


### PR DESCRIPTION
修复半个像素时内部图标抖动问题：

#### before
![Kapture 2019-05-28 at 22 26 21](https://user-images.githubusercontent.com/5378891/58486212-ff9c7800-8197-11e9-98af-40de6fdae735.gif)

#### after
![Kapture 2019-05-28 at 22 27 02](https://user-images.githubusercontent.com/5378891/58486229-06c38600-8198-11e9-88af-b0dcb7ed2268.gif)

ref: https://github.com/ant-design/ant-design/issues/15485

cc @afc163 @noctiomg