### PR TITLE
Fix align when rendering stuff outside the body tag

### DIFF
--- a/src/getOffsetParent.js
+++ b/src/getOffsetParent.js
@@ -38,7 +38,7 @@ function getOffsetParent(element) {
 
   for (
     parent = getParent(element);
-    parent && parent !== body;
+    parent && parent !== body && parent.nodeType !== 9;
     parent = getParent(parent)
   ) {
     positionStyle = utils.css(parent, 'position');


### PR DESCRIPTION
When rendering outside the `<body>` tag, getComputedStyle and other APIs fail because `#document` gets passed into them. This should fix that.