### PR TITLE
fix: the value of newPoint was incorrectly update

### DIFF
--- a/src/align/align.js
+++ b/src/align/align.js
@@ -186,14 +186,14 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
     if (isStillFailX || isStillFailY) {
       let newPoints = points;
 
-      // 重置对应部分的翻转逻辑
-      if (isStillFailX) {
+      // 重置可调整方向对应部分的翻转逻辑
+      if (overflow.adjustX && isStillFailX) {
         newPoints = flip(points, /[lr]/gi, {
           l: 'r',
           r: 'l',
         });
       }
-      if (isStillFailY) {
+      if (overflow.adjustY && isStillFailY) {
         newPoints = flip(points, /[tb]/gi, {
           t: 'b',
           b: 't',


### PR DESCRIPTION
1. 当设置overflow中adjustX 为true，adjustY为false时。进入调整方向步骤
```
  // 如果可视区域不能完全放置当前节点时允许调整
  if (
    visibleRect &&
    (overflow.adjustX || overflow.adjustY) &&
    isTgtRegionVisible
  ) {
    if (overflow.adjustX) {
````
2. 虽然Y方向不能放下，但是不允许进行方向调整。
```
    const isStillFailX = isFailX(elFuturePos, elRegion, visibleRect); // false
    const isStillFailY = isFailY(elFuturePos, elRegion, visibleRect); // true
    // 检查反下后的位置是否可以放下了，如果仍然放不下：
    // 1. 复原修改过的定位参数
    if (isStillFailX || isStillFailY) {
      let newPoints = points;

      // 重置可调整方向对应部分的翻转逻辑
      if (isStillFailX) {
        newPoints = flip(points, /[lr]/gi, {
          l: 'r',
          r: 'l',
        });
      }
      if (isStillFailY) {
        newPoints = flip(points, /[tb]/gi, {
          t: 'b',
          b: 't',
        });
      }
```
**此时Y方向的point其实没有修改过，所以不需要进行重置。**
**但此时判断进行了重置，相当于进行了翻转**
