### PR TITLE
fix: Clip should be by documentElement.clientWidth/clientHeight

### DIFF
--- a/src/getVisibleRectForElement.js
+++ b/src/getVisibleRectForElement.js
@@ -94,10 +94,10 @@ function getVisibleRectForElement(element, alwaysByViewport) {
     visibleRect.bottom = Math.min(visibleRect.bottom, scrollY + viewportHeight);
   } else {
     // Clip by document's size.
-    const maxVisibleWidth = Math.max(documentWidth, scrollX + viewportWidth);
+    const maxVisibleWidth = Math.max(documentElement.clientWidth, scrollX + viewportWidth);
     visibleRect.right = Math.min(visibleRect.right, maxVisibleWidth);
 
-    const maxVisibleHeight = Math.max(documentHeight, scrollY + viewportHeight);
+    const maxVisibleHeight = Math.max(documentElement.clientHeight, scrollY + viewportHeight);
     visibleRect.bottom = Math.min(visibleRect.bottom, maxVisibleHeight);
   }
 


### PR DESCRIPTION
修复 可视区域的计算，应该被 documentElement 的 clientWidth/clientHeight 裁剪，否则，弹框将显示到出可视范围外去(如下图)

### 前置条件： 图片中的滚动条为 window 的滚动条，其他容器的 overflow 均为 visible 

### 实际结果：
![image](https://user-images.githubusercontent.com/17830872/97171086-c8d0f400-17c7-11eb-944d-19b4fff4fd25.png)
### 预期结果：
![image](https://user-images.githubusercontent.com/17830872/97171996-5103c900-17c9-11eb-8d11-87fa4ec768e4.png)
