### PR TITLE
perf: record the last offset to avoid the style recalculation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -220,6 +220,16 @@ function oppositeOffsetDirection(dir) {
 
 // 设置 elem 相对 elem.ownerDocument 的坐标
 function setLeftTop(elem, offset, option) {
+  // calling getOffset () will trigger the style recalculation, which has a
+  // high performance cost, so if offset is the same as the last recorded,
+  // we should skip this operation.
+  if (
+    elem._domAlignOffset &&
+    elem._domAlignOffset.left === offset.left &&
+    elem._domAlignOffset.top === offset.top
+  ) {
+    return;
+  }
   // set position first, in-case top/left are set even on static elem
   if (css(elem, 'position') === 'static') {
     elem.style.position = 'relative';
@@ -289,6 +299,7 @@ function setLeftTop(elem, offset, option) {
     }
   }
   css(elem, ret);
+  elem._domAlignOffset = offset;
 }
 
 function setTransform(elem, offset) {
@@ -487,9 +498,7 @@ function getWH(elem, name, ex) {
   const val = borderBoxValue || cssBoxValue;
   if (extra === CONTENT_INDEX) {
     if (borderBoxValueOrIsBorderBox) {
-      return (
-        val - getPBMWidth(elem, ['border', 'padding'], which)
-      );
+      return val - getPBMWidth(elem, ['border', 'padding'], which);
     }
     return cssBoxValue;
   } else if (borderBoxValueOrIsBorderBox) {
@@ -503,10 +512,7 @@ function getWH(elem, name, ex) {
         : getPBMWidth(elem, ['margin'], which))
     );
   }
-  return (
-    cssBoxValue +
-    getPBMWidth(elem, BOX_MODELS.slice(extra), which)
-  );
+  return cssBoxValue + getPBMWidth(elem, BOX_MODELS.slice(extra), which);
 }
 
 const cssShow = {


### PR DESCRIPTION
在测试 Select 组件的时候，我发现打开和关闭 Select 组件时有明显卡顿现象，用浏览器开发者工具进行性能分析后的结果如下：

![2021-05-21 16-58-19 dom-align-before](https://user-images.githubusercontent.com/1730073/119111777-fa582800-ba55-11eb-9d8a-e8959c6ed01b.png)

![2021-05-21 16-58-45 dom-align-before](https://user-images.githubusercontent.com/1730073/119111795-ff1cdc00-ba55-11eb-931f-0f11e68b6b31.png)

图中选中的时间范围包含了一次 Select 组件的打开和关闭操作，从调用树中可以看出 setLeftTop() 函数触发的样式重计算耗时 240ms 。

考虑到大多数情况下 select 组件的位置不会改变，每次调用 setLeftTop() 函数给元素设置的 offset 与上次是相同的，因此给 setLeftTop() 加了个 offset 记录功能，仅在 offset 值与上次的不一致时才继续操作。

以下是优化后的性能分析结果，实测 Select 组件的打开和关闭速度有明显提升。

![2021-05-21 16-24-20 dom-align-after](https://user-images.githubusercontent.com/1730073/119110803-0b546980-ba55-11eb-9aba-b4f4d7f6a2ea.png)
