### PR TITLE
fix(isAncestorFixed):fix isAncestorFixed crash caused by document.documentElement

### DIFF
--- a/src/isAncestorFixed.js
+++ b/src/isAncestorFixed.js
@@ -12,7 +12,8 @@ export default function isAncestorFixed(element) {
   let parent = null;
   for (
     parent = getParent(element);
-    parent && parent !== body;
+    // 修复元素位于 document.documentElement 下导致崩溃问题
+    parent && parent !== body && parent !== doc;
     parent = getParent(parent)
   ) {
     const positionStyle = utils.css(parent, 'position');


### PR DESCRIPTION
在开发扩展使用 antd 的 Tooltip 组件时一直崩溃，经过排查原因如下：

主要原因是：antd 的 Tooltip  内部使用了该库进行 dom 对齐操作

扩展由于需求问题，不能把组件渲染进 body 内部，而是构建成 body 的兄弟节点

下面的代码对 body 做了判断就会导致循环进入 document 元素之上，导致 utils.css(parent, 'position') 直接崩溃报错
