### PR TITLE
fix: element may overflow  container

### DIFF
--- a/src/getVisibleRectForElement.js
+++ b/src/getVisibleRectForElement.js
@@ -29,7 +29,9 @@ function getVisibleRectForElement(element, alwaysByViewport) {
       // document.documentElement, so check for that too.
       (el !== body &&
         el !== documentElement &&
-        utils.css(el, 'overflow') !== 'visible')
+        utils.css(el, 'overflow') !== 'visible') &&
+      // 排除从dom树中移除节点，vue-frag等框架通过实现虚拟节点实现Fragment效果
+      body.contains(el)
     ) {
       const pos = utils.offset(el);
       // add border


### PR DESCRIPTION
当节点路径中存在虚拟节点（如：vue-frag实现Fragment生成的虚拟element）时，无法准确计算容器的高宽，导致元素超出容器
