### PR TITLE
fix: use function getWH will get different result

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -477,7 +477,7 @@ function getWH(elem, name, ex) {
       cssBoxValue = elem.style[name] || 0;
     }
     // Normalize '', auto, and prepare for extra
-    cssBoxValue = parseFloat(cssBoxValue) || 0;
+    cssBoxValue = Math.floor(parseFloat(cssBoxValue)) || 0;
   }
   if (extra === undefined) {
     extra = isBorderBox ? BORDER_INDEX : CONTENT_INDEX;


### PR DESCRIPTION
this problem is #66  casued
the property borderBoxValue  used Math.floor, but property cssBoxValue does not