### PR TITLE
Update isAncestorFixed.js

### DIFF
--- a/src/isAncestorFixed.js
+++ b/src/isAncestorFixed.js
@@ -17,7 +17,7 @@ export default function isAncestorFixed(element) {
     parent = getParent(parent)
   ) {
     const positionStyle = utils.css(parent, 'position');
-    if (positionStyle === 'fixed') {
+    if (positionStyle === 'fixed' || positionStyle === 'sticky') {
       return true;
     }
   }


### PR DESCRIPTION
修复当祖先元素为 sticky 时的定位问题