### PR TITLE
feat: add overflow.lockedPoints

### DIFF
--- a/examples/simple.html
+++ b/examples/simple.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <div id="__react-content" />
+
+    <script src="./simple.js" module></script>
+</body>
+</html>

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -23,6 +23,7 @@ function align() {
     overflow: {
       adjustX: $id('adjustX').checked,
       adjustY: $id('adjustY').checked,
+      lockedPoints: $id('lockedPoints').checked,
     },
     useCssRight: $id('useCssRight').checked,
     useCssBottom: $id('useCssBottom').checked,
@@ -79,6 +80,11 @@ const div = (
       </label>
       &nbsp;
       <label>
+        lockedPoints:
+        <input type="checkbox" id="lockedPoints" />
+      </label>
+      &nbsp;
+      <label>
         useCssBottom:
         <input type="checkbox" id="useCssBottom" />
       </label>
@@ -131,7 +137,7 @@ const div = (
           style={{
             background: 'red',
             width: 80,
-            height: 80,
+            height: 370,
             left: 0,
             top: 0,
             position: 'absolute',

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -137,7 +137,7 @@ const div = (
           style={{
             background: 'red',
             width: 80,
-            height: 370,
+            height: 360,
             left: 0,
             top: 0,
             position: 'absolute',

--- a/src/align/align.js
+++ b/src/align/align.js
@@ -115,27 +115,32 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
     if (overflow.adjustX) {
       // 如果横向不能放下
       if (isFailX(elFuturePos, elRegion, visibleRect)) {
-        // 对齐位置反下
-        const newPoints = flip(points, /[lr]/gi, {
-          l: 'r',
-          r: 'l',
-        });
-        // 偏移量也反下
-        const newOffset = flipOffset(offset, 0);
-        const newTargetOffset = flipOffset(targetOffset, 0);
-        const newElFuturePos = getElFuturePos(
-          elRegion,
-          tgtRegion,
-          newPoints,
-          newOffset,
-          newTargetOffset,
-        );
+        // 不锁定对齐点的话将会做对齐镜像操作
+        if (!overflow.lockedPoints) {
+          // 对齐位置反下
+          const newPoints = flip(points, /[lr]/gi, {
+            l: 'r',
+            r: 'l',
+          });
+          // 偏移量也反下
+          const newOffset = flipOffset(offset, 0);
+          const newTargetOffset = flipOffset(targetOffset, 0);
+          const newElFuturePos = getElFuturePos(
+            elRegion,
+            tgtRegion,
+            newPoints,
+            newOffset,
+            newTargetOffset,
+          );
 
-        if (!isCompleteFailX(newElFuturePos, elRegion, visibleRect)) {
+          if (!isCompleteFailX(newElFuturePos, elRegion, visibleRect)) {
+            fail = 1;
+            points = newPoints;
+            offset = newOffset;
+            targetOffset = newTargetOffset;
+          }
+        } else {
           fail = 1;
-          points = newPoints;
-          offset = newOffset;
-          targetOffset = newTargetOffset;
         }
       }
     }
@@ -143,27 +148,32 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
     if (overflow.adjustY) {
       // 如果纵向不能放下
       if (isFailY(elFuturePos, elRegion, visibleRect)) {
-        // 对齐位置反下
-        const newPoints = flip(points, /[tb]/gi, {
-          t: 'b',
-          b: 't',
-        });
-        // 偏移量也反下
-        const newOffset = flipOffset(offset, 1);
-        const newTargetOffset = flipOffset(targetOffset, 1);
-        const newElFuturePos = getElFuturePos(
-          elRegion,
-          tgtRegion,
-          newPoints,
-          newOffset,
-          newTargetOffset,
-        );
+        // 不锁定对齐点的话将会做对齐镜像操作
+        if (!overflow.lockedPoints) {
+          // 对齐位置反下
+          const newPoints = flip(points, /[tb]/gi, {
+            t: 'b',
+            b: 't',
+          });
+          // 偏移量也反下
+          const newOffset = flipOffset(offset, 1);
+          const newTargetOffset = flipOffset(targetOffset, 1);
+          const newElFuturePos = getElFuturePos(
+            elRegion,
+            tgtRegion,
+            newPoints,
+            newOffset,
+            newTargetOffset,
+          );
 
-        if (!isCompleteFailY(newElFuturePos, elRegion, visibleRect)) {
+          if (!isCompleteFailY(newElFuturePos, elRegion, visibleRect)) {
+            fail = 1;
+            points = newPoints;
+            offset = newOffset;
+            targetOffset = newTargetOffset;
+          }
+        } else {
           fail = 1;
-          points = newPoints;
-          offset = newOffset;
-          targetOffset = newTargetOffset;
         }
       }
     }
@@ -183,7 +193,7 @@ function doAlign(el, tgtRegion, align, isTgtRegionVisible) {
     const isStillFailY = isFailY(elFuturePos, elRegion, visibleRect);
     // 检查反下后的位置是否可以放下了，如果仍然放不下：
     // 1. 复原修改过的定位参数
-    if (isStillFailX || isStillFailY) {
+    if ((isStillFailX || isStillFailY) && !overflow.lockedPoints) {
       let newPoints = points;
 
       // 重置对应部分的翻转逻辑


### PR DESCRIPTION
# 动机

项目里使用了 antd 的 Popover 组件，然后发现他的对齐适配规则不符合需求，阅读源码后发现底层依赖的是 dom-align ，也就是当前这个库。研究完发现想要解决问题最好的方式是优化下这个库，相信这个问题很多人也会这类需求。

# 目标

当容器空间不足于放下元素时，经常需要做适配调整，而适配规则可以有三种：

1. 不做适配
2. 切换另一种对齐规则，例如原本是顶端对齐，切换到底端对齐
3. 往空间充裕的地方偏移

这个库目前支持前面两种，我期望能实现第三种。

## 1. 不做适配

不配置 overflow 值

![image](https://user-images.githubusercontent.com/17026576/222677345-f380fb46-a807-4d71-9748-8ad4bccd8476.png)

## 2. 切换对齐规则

overflow.adjustY = 1

![image](https://user-images.githubusercontent.com/17026576/222677499-57ce399e-42a6-4198-86d7-d11e3c51135c.png)

## 3. 往空间充裕的地方偏移

overflow.adjustY = 1
overflow.lockedPoints = 1

![image](https://user-images.githubusercontent.com/17026576/222677584-37491acf-d25a-492b-96ff-9e0205f5f995.png)

# 提案内容

## 支持第三种适配规则

overflow 增加 lockedPoints 字段

```diff
{
    points: [string, string];
    offset: [nubmer, number];
    targetOffset: [number, number];
    overflow: {
        adjustX: boolean;
        adjustY: boolean;
        alwaysByViewport: boolean;
+       lockedPoints: boolean
    }
}
```

为什么字段名叫 lockedPoints 呢？

在原有的适配规则是切换对齐规则，也就是对 points 做反下，偏移量相应的也反下。在新的适配规则里，只是不做对齐规则切换，其他的逻辑都保持一致。这个动作更像是把 points 对齐规则锁定住，也就是 points 是否被锁定的问题。






